### PR TITLE
Add Scene Duplicator editor tool

### DIFF
--- a/Assets/Editor/SceneDuplicator.cs
+++ b/Assets/Editor/SceneDuplicator.cs
@@ -1,0 +1,86 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public class SceneDuplicator : EditorWindow
+{
+    private string newSceneName = "";
+    private bool addToBuildSettings = true;
+
+    [MenuItem("Tools/Scene Duplicator")]
+    public static void OpenWindow()
+    {
+        GetWindow<SceneDuplicator>("Scene Duplicator");
+    }
+
+    private void OnGUI()
+    {
+        GUILayout.Label("Duplicate selected .unity scene", EditorStyles.boldLabel);
+
+        var selected = Selection.activeObject;
+        string selectedPath = selected ? AssetDatabase.GetAssetPath(selected) : "";
+
+        EditorGUILayout.LabelField("Selected:", string.IsNullOrEmpty(selectedPath) ? "<none>" : selectedPath);
+
+        EditorGUILayout.Space();
+
+        newSceneName = EditorGUILayout.TextField("New scene name (no extension, leave empty to auto)", newSceneName);
+        addToBuildSettings = EditorGUILayout.Toggle("Add to Build Settings", addToBuildSettings);
+
+        EditorGUILayout.Space();
+
+        GUI.enabled = !string.IsNullOrEmpty(selectedPath) && selectedPath.EndsWith(".unity");
+        if (GUILayout.Button("Duplicate Scene"))
+        {
+            DuplicateScene(selectedPath, newSceneName, addToBuildSettings);
+        }
+        GUI.enabled = true;
+    }
+
+    private static void DuplicateScene(string srcPath, string newName, bool addToBuild)
+    {
+        string dir = Path.GetDirectoryName(srcPath).Replace("\\", "/");
+        string srcFileName = Path.GetFileNameWithoutExtension(srcPath);
+
+        // Determine base destination name
+        string baseName = string.IsNullOrEmpty(newName) ? (srcFileName + "_Copy") : newName;
+        string destPath = Path.Combine(dir, baseName + ".unity").Replace("\\", "/");
+
+        // If destination exists, auto-increment: base, base1, base2, ...
+        if (AssetDatabase.LoadAssetAtPath<Object>(destPath) != null)
+        {
+            int i = 1;
+            string tryPath;
+            do
+            {
+                tryPath = Path.Combine(dir, $"{baseName}{i}.unity").Replace("\\", "/");
+                i++;
+            } while (AssetDatabase.LoadAssetAtPath<Object>(tryPath) != null);
+
+            destPath = tryPath;
+        }
+
+        bool ok = AssetDatabase.CopyAsset(srcPath, destPath);
+        if (!ok)
+        {
+            EditorUtility.DisplayDialog("Error", $"Failed to copy asset from:\n{srcPath}\n\nto:\n{destPath}", "OK");
+            return;
+        }
+
+        AssetDatabase.Refresh();
+        EditorUtility.DisplayDialog("Success", $"Scene duplicated to:\n{destPath}", "OK");
+
+        if (addToBuild)
+        {
+            var list = new System.Collections.Generic.List<EditorBuildSettingsScene>(EditorBuildSettings.scenes);
+            // Avoid adding duplicate entries for same path
+            bool already = list.Exists(s => s.path == destPath);
+            if (!already)
+            {
+                list.Add(new EditorBuildSettingsScene(destPath, true));
+                EditorBuildSettings.scenes = list.ToArray();
+                EditorUtility.DisplayDialog("Build Settings", "Added duplicated scene to Build Settings.", "OK");
+            }
+        }
+    }
+}


### PR DESCRIPTION
概要:
Project ウィンドウで選択したシーン（.unity）を複製する Unity Editor ウィンドウを追加します。複製時に名前を指定でき、未指定なら元ファイル名に `_Copy` を付与します。既に同名のファイルがある場合は自動でインクリメント（_Copy1, _Copy2...）します。オプションで Build Settings に自動追加できます。

変更点:
- Assets/Editor/SceneDuplicator.cs を追加

動作確認手順:
1. Unity でプロジェクトを開く。
2. Project ウィンドウで .unity シーンを選択。
3. メニュー → Tools → Scene Duplicator を開き、Duplicate Scene を押す。
4. 複製されたシーンが Assets に作成されることを確認。